### PR TITLE
aws_request_signing: extend api to allow header exclusion

### DIFF
--- a/api/envoy/extensions/filters/http/aws_request_signing/v3/BUILD
+++ b/api/envoy/extensions/filters/http/aws_request_signing/v3/BUILD
@@ -5,5 +5,8 @@ load("@envoy_api//bazel:api_build_system.bzl", "api_proto_package")
 licenses(["notice"])  # Apache 2
 
 api_proto_package(
-    deps = ["@com_github_cncf_udpa//udpa/annotations:pkg"],
+    deps = [
+        "//envoy/type/matcher/v3:pkg",
+        "@com_github_cncf_udpa//udpa/annotations:pkg",
+    ],
 )

--- a/api/envoy/extensions/filters/http/aws_request_signing/v3/aws_request_signing.proto
+++ b/api/envoy/extensions/filters/http/aws_request_signing/v3/aws_request_signing.proto
@@ -52,6 +52,13 @@ message AwsRequestSigning {
   // <https://docs.aws.amazon.com/AmazonS3/latest/API/sig-v4-header-based-auth.html>`_ policy for details.
   bool use_unsigned_payload = 4;
 
-  // A given header that matches any of the configured matchers will not be signed.
+  // A list of request header string matchers that will be excluded from signing. The excluded header can be matched by
+  // any patterns defined in the StringMatcher proto (e.g. exact string, prefix, regex, etc).
+  // Example:
+  // match_excluded_headers:
+  //  - prefix: x-envoy
+  //  - exact: foo
+  //  - exact: bar
+  // When applied, all headers that start with "x-envoy" and headers "foo" and "bar" will not be signed.
   repeated type.matcher.v3.StringMatcher match_excluded_headers = 5;
 }

--- a/api/envoy/extensions/filters/http/aws_request_signing/v3/aws_request_signing.proto
+++ b/api/envoy/extensions/filters/http/aws_request_signing/v3/aws_request_signing.proto
@@ -2,6 +2,8 @@ syntax = "proto3";
 
 package envoy.extensions.filters.http.aws_request_signing.v3;
 
+import "envoy/type/matcher/v3/string.proto";
+
 import "udpa/annotations/status.proto";
 import "udpa/annotations/versioning.proto";
 import "validate/validate.proto";
@@ -16,6 +18,7 @@ option (udpa.annotations.file_status).package_version_status = ACTIVE;
 // [#extension: envoy.filters.http.aws_request_signing]
 
 // Top level configuration for the AWS request signing filter.
+// [#next-free-field: 6]
 message AwsRequestSigning {
   option (udpa.annotations.versioning).previous_message_type =
       "envoy.config.filter.http.aws_request_signing.v2alpha.AwsRequestSigning";
@@ -48,4 +51,7 @@ message AwsRequestSigning {
   // to calculate the payload hash. Not all services support this option. See the `S3
   // <https://docs.aws.amazon.com/AmazonS3/latest/API/sig-v4-header-based-auth.html>`_ policy for details.
   bool use_unsigned_payload = 4;
+
+  // A given header that matches any of the configured matchers will not be signed.
+  repeated type.matcher.v3.StringMatcher match_excluded_headers = 5;
 }

--- a/ci/run_envoy_docker.sh
+++ b/ci/run_envoy_docker.sh
@@ -98,5 +98,6 @@ docker run --rm \
        -e SYSTEM_STAGEDISPLAYNAME \
        -e SYSTEM_JOBDISPLAYNAME \
        -e SYSTEM_PULLREQUEST_PULLREQUESTNUMBER \
+       -e GOPROXY=direct \
        "${ENVOY_BUILD_IMAGE}" \
        "${START_COMMAND[@]}"

--- a/ci/run_envoy_docker.sh
+++ b/ci/run_envoy_docker.sh
@@ -98,6 +98,5 @@ docker run --rm \
        -e SYSTEM_STAGEDISPLAYNAME \
        -e SYSTEM_JOBDISPLAYNAME \
        -e SYSTEM_PULLREQUEST_PULLREQUESTNUMBER \
-       -e GOPROXY=direct \
        "${ENVOY_BUILD_IMAGE}" \
        "${START_COMMAND[@]}"

--- a/docs/root/configuration/http/http_filters/aws_request_signing_filter.rst
+++ b/docs/root/configuration/http/http_filters/aws_request_signing_filter.rst
@@ -25,6 +25,10 @@ When :ref:`use_unsigned_payload <envoy_v3_api_field_extensions.filters.http.aws_
 is false (the default), requests which exceed the configured buffer limit will receive a 413 response. See the
 ref:`flow control docs <faq_flow_control>` for details.
 
+The :ref:`match_excluded_headers <envoy_v3_api_field_extensions.filters.http.aws_request_signing.v3.AwsRequestSigning.match_excluded_headers>`
+option allows excluding certain request headers from being signed. This usually applies to headers that are likely to mutate or
+are added later such as in retries.
+
 Example configuration
 ---------------------
 
@@ -38,6 +42,10 @@ Example filter configuration:
     service_name: s3
     region: us-west-2
     use_unsigned_payload: true
+    match_excluded_headers:
+        - prefix: x-envoy
+        - prefix: x-forwarded
+        - exact: x-amzn-trace-id
 
 
 Statistics

--- a/source/extensions/common/aws/BUILD
+++ b/source/extensions/common/aws/BUILD
@@ -27,7 +27,6 @@ envoy_cc_library(
         "//source/common/buffer:buffer_lib",
         "//source/common/common:hex_lib",
         "//source/common/common:logger_lib",
-        "//source/common/common:matchers_lib",
         "//source/common/common:utility_lib",
         "//source/common/crypto:utility_lib",
         "//source/common/http:headers_lib",

--- a/source/extensions/common/aws/BUILD
+++ b/source/extensions/common/aws/BUILD
@@ -27,6 +27,7 @@ envoy_cc_library(
         "//source/common/buffer:buffer_lib",
         "//source/common/common:hex_lib",
         "//source/common/common:logger_lib",
+        "//source/common/common:matchers_lib",
         "//source/common/common:utility_lib",
         "//source/common/crypto:utility_lib",
         "//source/common/http:headers_lib",
@@ -62,6 +63,7 @@ envoy_cc_library(
     external_deps = ["curl"],
     deps = [
         "//source/common/common:empty_string",
+        "//source/common/common:matchers_lib",
         "//source/common/common:utility_lib",
         "//source/common/http:headers_lib",
     ],

--- a/source/extensions/common/aws/signer_impl.cc
+++ b/source/extensions/common/aws/signer_impl.cc
@@ -57,7 +57,7 @@ void SignerImpl::sign(Http::RequestHeaderMap& headers, const std::string& conten
   const auto short_date = short_date_formatter_.now(time_source_);
   headers.addCopy(SignatureHeaders::get().Date, long_date);
   // Phase 1: Create a canonical request
-  const auto canonical_headers = Utility::canonicalizeHeaders(headers);
+  const auto canonical_headers = Utility::canonicalizeHeaders(headers, excluded_header_matchers_);
   const auto canonical_request = Utility::createCanonicalRequest(
       service_name_, method_header->value().getStringView(), path_header->value().getStringView(),
       canonical_headers, content_hash);

--- a/source/extensions/common/aws/signer_impl.h
+++ b/source/extensions/common/aws/signer_impl.h
@@ -84,16 +84,16 @@ private:
                                         const std::map<std::string, std::string>& canonical_headers,
                                         absl::string_view signature) const;
 
-  std::vector<Matchers::StringMatcherPtr> defaultMatchers() {
-    std::vector<Matchers::StringMatcherPtr> default_excluded_headers{};
+  std::vector<Matchers::StringMatcherPtr> defaultMatchers() const {
+    std::vector<Matchers::StringMatcherPtr> matcher_ptrs{};
     for (const auto& header : default_excluded_headers_) {
       envoy::type::matcher::v3::StringMatcher m;
       m.set_exact(header);
-      default_excluded_headers.emplace_back(
+      matcher_ptrs.emplace_back(
           std::make_unique<Matchers::StringMatcherImpl<envoy::type::matcher::v3::StringMatcher>>(
               m));
     }
-    return default_excluded_headers;
+    return matcher_ptrs;
   }
 
   const std::string service_name_;

--- a/source/extensions/common/aws/utility.cc
+++ b/source/extensions/common/aws/utility.cc
@@ -24,36 +24,43 @@ const std::string URI_ENCODE = "%{:02X}";
 const std::string URI_DOUBLE_ENCODE = "%25{:02X}";
 
 std::map<std::string, std::string>
-Utility::canonicalizeHeaders(const Http::RequestHeaderMap& headers) {
+Utility::canonicalizeHeaders(const Http::RequestHeaderMap& headers,
+                             const std::vector<Matchers::StringMatcherPtr>& excluded_headers) {
   std::map<std::string, std::string> out;
-  headers.iterate([&out](const Http::HeaderEntry& entry) -> Http::HeaderMap::Iterate {
-    // Skip empty headers
-    if (entry.key().empty() || entry.value().empty()) {
-      return Http::HeaderMap::Iterate::Continue;
-    }
-    // Pseudo-headers should not be canonicalized
-    if (!entry.key().getStringView().empty() && entry.key().getStringView()[0] == ':') {
-      return Http::HeaderMap::Iterate::Continue;
-    }
-    // Skip headers that are likely to mutate, when crossing proxies
-    const auto key = entry.key().getStringView();
-    if (key == Http::Headers::get().ForwardedFor.get() ||
-        key == Http::Headers::get().ForwardedProto.get() || key == "x-amzn-trace-id") {
-      return Http::HeaderMap::Iterate::Continue;
-    }
+  headers.iterate(
+      [&out, &excluded_headers](const Http::HeaderEntry& entry) -> Http::HeaderMap::Iterate {
+        // Skip empty headers
+        if (entry.key().empty() || entry.value().empty()) {
+          return Http::HeaderMap::Iterate::Continue;
+        }
+        // Pseudo-headers should not be canonicalized
+        if (!entry.key().getStringView().empty() && entry.key().getStringView()[0] == ':') {
+          return Http::HeaderMap::Iterate::Continue;
+        }
+        // Skip headers that are in the exclusion list and/or are likely to mutate when crossing
+        // proxies
+        const auto key = entry.key().getStringView();
+        if (key == Http::Headers::get().ForwardedFor.get() ||
+            key == Http::Headers::get().ForwardedProto.get() || key == "x-amzn-trace-id" ||
+            std::any_of(excluded_headers.begin(), excluded_headers.end(),
+                        [&key](const Matchers::StringMatcherPtr& matcher) {
+                          return matcher->match(key);
+                        })) {
+          return Http::HeaderMap::Iterate::Continue;
+        }
 
-    std::string value(entry.value().getStringView());
-    // Remove leading, trailing, and deduplicate repeated ascii spaces
-    absl::RemoveExtraAsciiWhitespace(&value);
-    const auto iter = out.find(std::string(entry.key().getStringView()));
-    // If the entry already exists, append the new value to the end
-    if (iter != out.end()) {
-      iter->second += fmt::format(",{}", value);
-    } else {
-      out.emplace(std::string(entry.key().getStringView()), value);
-    }
-    return Http::HeaderMap::Iterate::Continue;
-  });
+        std::string value(entry.value().getStringView());
+        // Remove leading, trailing, and deduplicate repeated ascii spaces
+        absl::RemoveExtraAsciiWhitespace(&value);
+        const auto iter = out.find(std::string(entry.key().getStringView()));
+        // If the entry already exists, append the new value to the end
+        if (iter != out.end()) {
+          iter->second += fmt::format(",{}", value);
+        } else {
+          out.emplace(std::string(entry.key().getStringView()), value);
+        }
+        return Http::HeaderMap::Iterate::Continue;
+      });
   // The AWS SDK has a quirk where it removes "default ports" (80, 443) from the host headers
   // Additionally, we canonicalize the :authority header as "host"
   // TODO(lavignes): This may need to be tweaked to canonicalize :authority for HTTP/2 requests

--- a/source/extensions/common/aws/utility.cc
+++ b/source/extensions/common/aws/utility.cc
@@ -37,12 +37,8 @@ Utility::canonicalizeHeaders(const Http::RequestHeaderMap& headers,
         if (!entry.key().getStringView().empty() && entry.key().getStringView()[0] == ':') {
           return Http::HeaderMap::Iterate::Continue;
         }
-        // Skip headers that are in the exclusion list and/or are likely to mutate when crossing
-        // proxies
         const auto key = entry.key().getStringView();
-        if (key == Http::Headers::get().ForwardedFor.get() ||
-            key == Http::Headers::get().ForwardedProto.get() || key == "x-amzn-trace-id" ||
-            std::any_of(excluded_headers.begin(), excluded_headers.end(),
+        if (std::any_of(excluded_headers.begin(), excluded_headers.end(),
                         [&key](const Matchers::StringMatcherPtr& matcher) {
                           return matcher->match(key);
                         })) {

--- a/source/extensions/common/aws/utility.h
+++ b/source/extensions/common/aws/utility.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "source/common/common/matchers.h"
 #include "source/common/http/headers.h"
 
 namespace Envoy {
@@ -13,10 +14,12 @@ public:
    * Creates a canonicalized header map used in creating a AWS Signature V4 canonical request.
    * See https://docs.aws.amazon.com/general/latest/gr/sigv4-create-canonical-request.html
    * @param headers a header map to canonicalize.
+   * @param excluded_headers a list of string matchers to exclude a given header from signing.
    * @return a std::map of canonicalized headers to be used in building a canonical request.
    */
   static std::map<std::string, std::string>
-  canonicalizeHeaders(const Http::RequestHeaderMap& headers);
+  canonicalizeHeaders(const Http::RequestHeaderMap& headers,
+                      const std::vector<Matchers::StringMatcherPtr>& excluded_headers);
 
   /**
    * Creates an AWS Signature V4 canonical request string.

--- a/source/extensions/filters/http/aws_lambda/config.cc
+++ b/source/extensions/filters/http/aws_lambda/config.cc
@@ -49,7 +49,7 @@ Http::FilterFactoryCb AwsLambdaFilterFactory::createFilterFactoryFromProtoTyped(
   auto signer = std::make_shared<Extensions::Common::Aws::SignerImpl>(
       service_name, region, std::move(credentials_provider),
       context.mainThreadDispatcher().timeSource(),
-      std::vector<envoy::type::matcher::v3::StringMatcher>{});
+      Extensions::Common::Aws::AwsSigV4HeaderExclusionVector{});
 
   FilterSettings filter_settings{*arn, getInvocationMode(proto_config),
                                  proto_config.payload_passthrough()};

--- a/source/extensions/filters/http/aws_lambda/config.cc
+++ b/source/extensions/filters/http/aws_lambda/config.cc
@@ -48,7 +48,8 @@ Http::FilterFactoryCb AwsLambdaFilterFactory::createFilterFactoryFromProtoTyped(
   const std::string region = arn->region();
   auto signer = std::make_shared<Extensions::Common::Aws::SignerImpl>(
       service_name, region, std::move(credentials_provider),
-      context.mainThreadDispatcher().timeSource());
+      context.mainThreadDispatcher().timeSource(),
+      std::vector<envoy::type::matcher::v3::StringMatcher>{});
 
   FilterSettings filter_settings{*arn, getInvocationMode(proto_config),
                                  proto_config.payload_passthrough()};

--- a/source/extensions/filters/http/aws_request_signing/BUILD
+++ b/source/extensions/filters/http/aws_request_signing/BUILD
@@ -32,6 +32,7 @@ envoy_cc_extension(
     deps = [
         ":aws_request_signing_filter_lib",
         "//envoy/registry",
+        "//source/common/common:matchers_lib",
         "//source/extensions/common/aws:credentials_provider_impl_lib",
         "//source/extensions/common/aws:signer_impl_lib",
         "//source/extensions/filters/http/common:factory_base_lib",

--- a/source/extensions/filters/http/aws_request_signing/config.cc
+++ b/source/extensions/filters/http/aws_request_signing/config.cc
@@ -21,7 +21,7 @@ Http::FilterFactoryCb AwsRequestSigningFilterFactory::createFilterFactoryFromPro
   auto credentials_provider =
       std::make_shared<Extensions::Common::Aws::DefaultCredentialsProviderChain>(
           context.api(), Extensions::Common::Aws::Utility::metadataFetcher);
-  const auto matcher_config = std::vector<envoy::type::matcher::v3::StringMatcher>(
+  const auto matcher_config = Extensions::Common::Aws::AwsSigV4HeaderExclusionVector(
       config.match_excluded_headers().begin(), config.match_excluded_headers().end());
   auto signer = std::make_unique<Extensions::Common::Aws::SignerImpl>(
       config.service_name(), config.region(), credentials_provider,

--- a/source/extensions/filters/http/aws_request_signing/config.cc
+++ b/source/extensions/filters/http/aws_request_signing/config.cc
@@ -21,10 +21,11 @@ Http::FilterFactoryCb AwsRequestSigningFilterFactory::createFilterFactoryFromPro
   auto credentials_provider =
       std::make_shared<Extensions::Common::Aws::DefaultCredentialsProviderChain>(
           context.api(), Extensions::Common::Aws::Utility::metadataFetcher);
+  const auto matcher_config = std::vector<envoy::type::matcher::v3::StringMatcher>(
+      config.match_excluded_headers().begin(), config.match_excluded_headers().end());
   auto signer = std::make_unique<Extensions::Common::Aws::SignerImpl>(
       config.service_name(), config.region(), credentials_provider,
-      context.mainThreadDispatcher().timeSource());
-
+      context.mainThreadDispatcher().timeSource(), matcher_config);
   auto filter_config =
       std::make_shared<FilterConfigImpl>(std::move(signer), stats_prefix, context.scope(),
                                          config.host_rewrite(), config.use_unsigned_payload());

--- a/source/extensions/grpc_credentials/aws_iam/config.cc
+++ b/source/extensions/grpc_credentials/aws_iam/config.cc
@@ -48,7 +48,7 @@ std::shared_ptr<grpc::ChannelCredentials> AwsIamGrpcCredentialsFactory::getChann
             api, Common::Aws::Utility::metadataFetcher);
         auto signer = std::make_unique<Common::Aws::SignerImpl>(
             config.service_name(), getRegion(config), credentials_provider, api.timeSource(),
-            std::vector<envoy::type::matcher::v3::StringMatcher>{});
+            Common::Aws::AwsSigV4HeaderExclusionVector{});
         std::shared_ptr<grpc::CallCredentials> new_call_creds = grpc::MetadataCredentialsFromPlugin(
             std::make_unique<AwsIamHeaderAuthenticator>(std::move(signer)));
         if (call_creds == nullptr) {

--- a/source/extensions/grpc_credentials/aws_iam/config.cc
+++ b/source/extensions/grpc_credentials/aws_iam/config.cc
@@ -47,7 +47,8 @@ std::shared_ptr<grpc::ChannelCredentials> AwsIamGrpcCredentialsFactory::getChann
         auto credentials_provider = std::make_shared<Common::Aws::DefaultCredentialsProviderChain>(
             api, Common::Aws::Utility::metadataFetcher);
         auto signer = std::make_unique<Common::Aws::SignerImpl>(
-            config.service_name(), getRegion(config), credentials_provider, api.timeSource());
+            config.service_name(), getRegion(config), credentials_provider, api.timeSource(),
+            std::vector<envoy::type::matcher::v3::StringMatcher>{});
         std::shared_ptr<grpc::CallCredentials> new_call_creds = grpc::MetadataCredentialsFromPlugin(
             std::make_unique<AwsIamHeaderAuthenticator>(std::move(signer)));
         if (call_creds == nullptr) {

--- a/test/extensions/common/aws/signer_impl_test.cc
+++ b/test/extensions/common/aws/signer_impl_test.cc
@@ -22,7 +22,7 @@ public:
       : credentials_provider_(new NiceMock<MockCredentialsProvider>()),
         message_(new Http::RequestMessageImpl()),
         signer_("service", "region", CredentialsProviderSharedPtr{credentials_provider_},
-                time_system_, std::vector<envoy::type::matcher::v3::StringMatcher>{}),
+                time_system_, Extensions::Common::Aws::AwsSigV4HeaderExclusionVector{}),
         credentials_("akid", "secret"), token_credentials_("akid", "secret", "token") {
     // 20180102T030405Z
     time_system_.setSystemTime(std::chrono::milliseconds(1514862245000));
@@ -48,7 +48,7 @@ public:
     headers.addCopy(Http::LowerCaseString("host"), "www.example.com");
 
     SignerImpl signer(service_name, "region", CredentialsProviderSharedPtr{credentials_provider},
-                      time_system_, std::vector<envoy::type::matcher::v3::StringMatcher>{});
+                      time_system_, Extensions::Common::Aws::AwsSigV4HeaderExclusionVector{});
     if (use_unsigned_payload) {
       signer.signUnsignedPayload(headers);
     } else {

--- a/test/extensions/common/aws/signer_impl_test.cc
+++ b/test/extensions/common/aws/signer_impl_test.cc
@@ -22,7 +22,7 @@ public:
       : credentials_provider_(new NiceMock<MockCredentialsProvider>()),
         message_(new Http::RequestMessageImpl()),
         signer_("service", "region", CredentialsProviderSharedPtr{credentials_provider_},
-                time_system_),
+                time_system_, std::vector<envoy::type::matcher::v3::StringMatcher>{}),
         credentials_("akid", "secret"), token_credentials_("akid", "secret", "token") {
     // 20180102T030405Z
     time_system_.setSystemTime(std::chrono::milliseconds(1514862245000));
@@ -48,7 +48,7 @@ public:
     headers.addCopy(Http::LowerCaseString("host"), "www.example.com");
 
     SignerImpl signer(service_name, "region", CredentialsProviderSharedPtr{credentials_provider},
-                      time_system_);
+                      time_system_, std::vector<envoy::type::matcher::v3::StringMatcher>{});
     if (use_unsigned_payload) {
       signer.signUnsignedPayload(headers);
     } else {

--- a/test/extensions/common/aws/utility_test.cc
+++ b/test/extensions/common/aws/utility_test.cc
@@ -19,7 +19,8 @@ TEST(UtilityTest, CanonicalizeHeadersInAlphabeticalOrder) {
       {"d", "d_value"}, {"f", "f_value"}, {"b", "b_value"},
       {"e", "e_value"}, {"c", "c_value"}, {"a", "a_value"},
   };
-  const auto map = Utility::canonicalizeHeaders(headers);
+  std::vector<Matchers::StringMatcherPtr> exclusion_list = {};
+  const auto map = Utility::canonicalizeHeaders(headers, exclusion_list);
   EXPECT_THAT(map, ElementsAre(Pair("a", "a_value"), Pair("b", "b_value"), Pair("c", "c_value"),
                                Pair("d", "d_value"), Pair("e", "e_value"), Pair("f", "f_value")));
 }
@@ -31,7 +32,8 @@ TEST(UtilityTest, CanonicalizeHeadersSkippingPseudoHeaders) {
       {":method", "GET"},
       {"normal", "normal_value"},
   };
-  const auto map = Utility::canonicalizeHeaders(headers);
+  std::vector<Envoy::Matchers::StringMatcherPtr> exclusion_list = {};
+  const auto map = Utility::canonicalizeHeaders(headers, exclusion_list);
   EXPECT_THAT(map, ElementsAre(Pair("normal", "normal_value")));
 }
 
@@ -42,7 +44,8 @@ TEST(UtilityTest, CanonicalizeHeadersJoiningDuplicatesWithCommas) {
       {"a", "a_value2"},
       {"a", "a_value3"},
   };
-  const auto map = Utility::canonicalizeHeaders(headers);
+  std::vector<Matchers::StringMatcherPtr> exclusion_list = {};
+  const auto map = Utility::canonicalizeHeaders(headers, exclusion_list);
   EXPECT_THAT(map, ElementsAre(Pair("a", "a_value1,a_value2,a_value3")));
 }
 
@@ -51,7 +54,8 @@ TEST(UtilityTest, CanonicalizeHeadersAuthorityToHost) {
   Http::TestRequestHeaderMapImpl headers{
       {":authority", "authority_value"},
   };
-  const auto map = Utility::canonicalizeHeaders(headers);
+  std::vector<Matchers::StringMatcherPtr> exclusion_list = {};
+  const auto map = Utility::canonicalizeHeaders(headers, exclusion_list);
   EXPECT_THAT(map, ElementsAre(Pair("host", "authority_value")));
 }
 
@@ -60,13 +64,14 @@ TEST(UtilityTest, CanonicalizeHeadersRemovingDefaultPortsFromHost) {
   Http::TestRequestHeaderMapImpl headers_port80{
       {":authority", "example.com:80"},
   };
-  const auto map_port80 = Utility::canonicalizeHeaders(headers_port80);
+  std::vector<Matchers::StringMatcherPtr> exclusion_list = {};
+  const auto map_port80 = Utility::canonicalizeHeaders(headers_port80, exclusion_list);
   EXPECT_THAT(map_port80, ElementsAre(Pair("host", "example.com")));
 
   Http::TestRequestHeaderMapImpl headers_port443{
       {":authority", "example.com:443"},
   };
-  const auto map_port443 = Utility::canonicalizeHeaders(headers_port443);
+  const auto map_port443 = Utility::canonicalizeHeaders(headers_port443, exclusion_list);
   EXPECT_THAT(map_port443, ElementsAre(Pair("host", "example.com")));
 }
 
@@ -78,20 +83,53 @@ TEST(UtilityTest, CanonicalizeHeadersTrimmingWhitespace) {
       {"internal", "internal    value"},
       {"all", "    all    value    "},
   };
-  const auto map = Utility::canonicalizeHeaders(headers);
+  std::vector<Matchers::StringMatcherPtr> exclusion_list = {};
+  const auto map = Utility::canonicalizeHeaders(headers, exclusion_list);
   EXPECT_THAT(map,
               ElementsAre(Pair("all", "all value"), Pair("internal", "internal value"),
                           Pair("leading", "leading value"), Pair("trailing", "trailing value")));
 }
 
 // Headers that are likely to mutate are not considered canonical
-TEST(UtilityTest, CanonicalizeHeadersDropMutatingHeaders) {
+TEST(UtilityTest, CanonicalizeHeadersDropMutatingHeadersDefault) {
   Http::TestRequestHeaderMapImpl headers{
       {":authority", "example.com"},          {"x-forwarded-for", "1.2.3.4"},
       {"x-forwarded-proto", "https"},         {"x-amz-date", "20130708T220855Z"},
       {"x-amz-content-sha256", "e3b0c44..."},
   };
-  const auto map = Utility::canonicalizeHeaders(headers);
+  std::vector<Matchers::StringMatcherPtr> exclusion_list = {};
+  const auto map = Utility::canonicalizeHeaders(headers, exclusion_list);
+  EXPECT_THAT(map,
+              ElementsAre(Pair("host", "example.com"), Pair("x-amz-content-sha256", "e3b0c44..."),
+                          Pair("x-amz-date", "20130708T220855Z")));
+}
+
+// Headers that match the exclusion list are not canonicalized
+TEST(UtilityTest, CanonicalizeHeadersDropMutatingHeadersWithExcludeMatchers) {
+  Http::TestRequestHeaderMapImpl headers{
+      {":authority", "example.com"},          {"x-forwarded-for", "1.2.3.4"},
+      {"x-forwarded-proto", "https"},         {"x-amz-date", "20130708T220855Z"},
+      {"x-amz-content-sha256", "e3b0c44..."}, {"x-envoy-retry-on", "5xx,reset"},
+      {"x-envoy-max-retries", "3"},           {"exact-match-header", "foo"},
+      {"exact-match-header-2", "bar"}};
+  std::vector<Matchers::StringMatcherPtr> exclusion_list = {};
+  std::vector<std::string> exact_matches = {"exact-match-header", "exact-match-header-2"};
+  for (auto& str : exact_matches) {
+    envoy::type::matcher::v3::StringMatcher config;
+    config.MergeFrom(TestUtility::createExactMatcher(str));
+    exclusion_list.emplace_back(
+        std::make_unique<Matchers::StringMatcherImpl<envoy::type::matcher::v3::StringMatcher>>(
+            config));
+  }
+  std::vector<std::string> prefixes = {"x-envoy"};
+  for (auto& match_str : prefixes) {
+    envoy::type::matcher::v3::StringMatcher config;
+    config.MergeFrom(TestUtility::createPrefixMatcher(match_str));
+    exclusion_list.emplace_back(
+        std::make_unique<Matchers::StringMatcherImpl<envoy::type::matcher::v3::StringMatcher>>(
+            config));
+  }
+  const auto map = Utility::canonicalizeHeaders(headers, exclusion_list);
   EXPECT_THAT(map,
               ElementsAre(Pair("host", "example.com"), Pair("x-amz-content-sha256", "e3b0c44..."),
                           Pair("x-amz-date", "20130708T220855Z")));

--- a/test/extensions/filters/http/aws_request_signing/config_test.cc
+++ b/test/extensions/filters/http/aws_request_signing/config_test.cc
@@ -21,6 +21,9 @@ TEST(AwsRequestSigningFilterConfigTest, SimpleConfig) {
   const std::string yaml = R"EOF(
 service_name: s3
 region: us-west-2
+match_excluded_headers:
+  prefix: [x-envoy]
+  exact: [foo]
   )EOF";
 
   AwsRequestSigningProtoConfig proto_config;

--- a/test/extensions/filters/http/aws_request_signing/config_test.cc
+++ b/test/extensions/filters/http/aws_request_signing/config_test.cc
@@ -22,8 +22,9 @@ TEST(AwsRequestSigningFilterConfigTest, SimpleConfig) {
 service_name: s3
 region: us-west-2
 match_excluded_headers:
-  prefix: [x-envoy]
-  exact: [foo]
+  - prefix: x-envoy
+  - exact: foo
+  - exact: bar
   )EOF";
 
   AwsRequestSigningProtoConfig proto_config;


### PR DESCRIPTION
<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message: extends aws request signing filter with header exclusion list.
Additional Description:
Risk Level: Low
Testing: unit tests
Docs Changes: Pending
Release Notes: Pending
Platform Specific Features: N/A
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
Fixes https://github.com/envoyproxy/envoy/issues/18695
