### PR TITLE
xray tracer: set subsegment type for child spans

### DIFF
--- a/source/extensions/tracers/xray/daemon.proto
+++ b/source/extensions/tracers/xray/daemon.proto
@@ -43,6 +43,9 @@ message Segment {
   }
   // Object containing one or more fields that X-Ray indexes for use with filter expressions.
   map<string, string> annotations = 8;
+  // Set type to "subsegment" when sending a child span so Xray treats it as a subsegment.
+  // https://docs.aws.amazon.com/xray/latest/devguide/xray-api-segmentdocuments.html#api-segmentdocuments-subsegments
+  string type = 14;
 }
 
 message Header {

--- a/source/extensions/tracers/xray/tracer.cc
+++ b/source/extensions/tracers/xray/tracer.cc
@@ -71,7 +71,9 @@ void Span::finishSpan() {
   s.set_error(clientError());
   s.set_fault(serverError());
   s.set_throttle(isThrottled());
-
+  if (type() == Subsegment) {
+    s.set_type(std::string(Subsegment));
+  }
   auto* aws = s.mutable_aws()->mutable_fields();
   for (const auto& field : aws_metadata_) {
     aws->insert({field.first, field.second});
@@ -115,6 +117,7 @@ Tracing::SpanPtr Span::spawnChild(const Tracing::Config& config, const std::stri
   child_span->setParentId(id());
   child_span->setTraceId(traceId());
   child_span->setSampled(sampled());
+  child_span->setType(Subsegment);
   return child_span;
 }
 

--- a/source/extensions/tracers/xray/tracer.h
+++ b/source/extensions/tracers/xray/tracer.h
@@ -26,6 +26,7 @@ namespace Tracers {
 namespace XRay {
 
 constexpr auto XRayTraceHeader = "x-amzn-trace-id";
+constexpr absl::string_view Subsegment = "subsegment";
 
 class Span : public Tracing::Span, Logger::Loggable<Logger::Id::config> {
 public:
@@ -102,6 +103,12 @@ public:
   }
 
   /**
+   * Sets the type of the Span. In Xray, an independent subsegment has a type of ``subsegment``.
+   * https://docs.aws.amazon.com/xray/latest/devguide/xray-api-segmentdocuments.html#api-segmentdocuments-subsegments
+   */
+  void setType(absl::string_view type) { type_ = std::string(type); }
+
+  /**
    * Sets the aws metadata field of the Span.
    */
   void setAwsMetadata(const absl::flat_hash_map<std::string, ProtobufWkt::Value>& aws_metadata) {
@@ -155,6 +162,11 @@ public:
    * Gets this Span's direction.
    */
   const std::string& direction() const { return direction_; }
+
+  /**
+   * Gets this Span's type.
+   */
+  const std::string& type() const { return type_; }
 
   /**
    * Gets this Span's name.
@@ -216,6 +228,7 @@ private:
   std::string parent_segment_id_;
   std::string name_;
   std::string origin_;
+  std::string type_;
   absl::flat_hash_map<std::string, ProtobufWkt::Value> aws_metadata_;
   absl::flat_hash_map<std::string, ProtobufWkt::Value> http_request_annotations_;
   absl::flat_hash_map<std::string, ProtobufWkt::Value> http_response_annotations_;

--- a/test/extensions/tracers/xray/tracer_test.cc
+++ b/test/extensions/tracers/xray/tracer_test.cc
@@ -97,6 +97,7 @@ TEST_F(XRayTracerTest, SerializeSpanTest) {
     EXPECT_FALSE(s.id().empty());
     EXPECT_EQ(2, s.annotations().size());
     EXPECT_TRUE(s.parent_id().empty());
+    EXPECT_TRUE(s.type().empty());
     EXPECT_FALSE(s.fault());    /*server error*/
     EXPECT_FALSE(s.error());    /*client error*/
     EXPECT_FALSE(s.throttle()); /*request throttled*/
@@ -142,6 +143,7 @@ TEST_F(XRayTracerTest, SerializeSpanTestServerError) {
     EXPECT_FALSE(s.trace_id().empty());
     EXPECT_FALSE(s.id().empty());
     EXPECT_TRUE(s.parent_id().empty());
+    EXPECT_TRUE(s.type().empty());
     EXPECT_TRUE(s.fault());  /*server error*/
     EXPECT_FALSE(s.error()); /*client error*/
     EXPECT_EQ(expected_status_code,
@@ -175,6 +177,7 @@ TEST_F(XRayTracerTest, SerializeSpanTestClientError) {
     EXPECT_FALSE(s.trace_id().empty());
     EXPECT_FALSE(s.id().empty());
     EXPECT_TRUE(s.parent_id().empty());
+    EXPECT_TRUE(s.type().empty());
     EXPECT_FALSE(s.fault());    /*server error*/
     EXPECT_TRUE(s.error());     /*client error*/
     EXPECT_FALSE(s.throttle()); /*request throttled*/
@@ -208,6 +211,7 @@ TEST_F(XRayTracerTest, SerializeSpanTestClientErrorWithThrottle) {
     EXPECT_FALSE(s.trace_id().empty());
     EXPECT_FALSE(s.id().empty());
     EXPECT_TRUE(s.parent_id().empty());
+    EXPECT_TRUE(s.type().empty());
     EXPECT_FALSE(s.fault());   /*server error*/
     EXPECT_TRUE(s.error());    /*client error*/
     EXPECT_TRUE(s.throttle()); /*request throttled*/
@@ -239,6 +243,7 @@ TEST_F(XRayTracerTest, SerializeSpanTestWithEmptyValue) {
     EXPECT_FALSE(s.trace_id().empty());
     EXPECT_FALSE(s.id().empty());
     EXPECT_TRUE(s.parent_id().empty());
+    EXPECT_TRUE(s.type().empty());
     EXPECT_FALSE(s.http().request().fields().contains(Tracing::Tags::get().Status));
   };
 
@@ -270,6 +275,7 @@ TEST_F(XRayTracerTest, SerializeSpanTestWithStatusCodeNotANumber) {
     EXPECT_FALSE(s.trace_id().empty());
     EXPECT_FALSE(s.id().empty());
     EXPECT_TRUE(s.parent_id().empty());
+    EXPECT_TRUE(s.type().empty());
     EXPECT_FALSE(s.http().request().fields().contains(Tracing::Tags::get().Status));
     EXPECT_FALSE(s.http().request().fields().contains("content_length"));
   };
@@ -347,6 +353,7 @@ TEST_F(XRayTracerTest, ChildSpanHasParentInfo) {
     // Hex encoded 64 bit identifier
     EXPECT_STREQ("00000000000003e7", s.parent_id().c_str());
     EXPECT_EQ(expected_->span_name, s.name().c_str());
+    EXPECT_TRUE(xray_parent_span->type().empty());
     EXPECT_EQ(Subsegment, s.type().c_str());
     EXPECT_STREQ(xray_parent_span->traceId().c_str(), s.trace_id().c_str());
     EXPECT_STREQ("0000003d25bebe62", s.id().c_str());

--- a/test/extensions/tracers/xray/tracer_test.cc
+++ b/test/extensions/tracers/xray/tracer_test.cc
@@ -347,6 +347,7 @@ TEST_F(XRayTracerTest, ChildSpanHasParentInfo) {
     // Hex encoded 64 bit identifier
     EXPECT_STREQ("00000000000003e7", s.parent_id().c_str());
     EXPECT_EQ(expected_->span_name, s.name().c_str());
+    EXPECT_EQ(Subsegment, s.type().c_str());
     EXPECT_STREQ(xray_parent_span->traceId().c_str(), s.trace_id().c_str());
     EXPECT_STREQ("0000003d25bebe62", s.id().c_str());
   };


### PR DESCRIPTION
Signed-off-by: Rex Chang <58710378+rexnp@users.noreply.github.com>

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message: xray tracer: sets the xray segment with type "subsegment" from child spans. 
xray doc: https://docs.aws.amazon.com/xray/latest/devguide/xray-api-segmentdocuments.html#api-segmentdocuments-subsegments
Additional Description:
Risk Level: low
Testing: unit test, manual setup verifying new xray behavior
Docs Changes: N/A
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue] https://github.com/aws/aws-app-mesh-roadmap/issues/354
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]

Here's a piece of the output with this change and using the same [howto-ecs-basics](https://github.com/aws/aws-app-mesh-examples/tree/main/walkthroughs/howto-ecs-basics) walkthrough:
in particular looking at the trace with `"name": "howto-ecs-basics/howto-ecs-basics-front-node"`, which is emitted by Envoy, it now contains a **subsegment** for the egress call to `cds_egress_howto-ecs-basics_howto-ecs-basics-color-node_http_8080`. Now, the only thing that remains is the fact that the name of this subsegment is the same as its parent `howto-ecs-basics/howto-ecs-basics-front-node`. We'll have to confirm what the intended behavior is.
```
        {
            "Id": "6ea5cd91017e6724",
            "Document": {
                "id": "6ea5cd91017e6724",
                "name": "howto-ecs-basics/howto-ecs-basics-front-node",
                "start_time": 1640120006.301012,
                "trace_id": "1-61c23ec6-3aa5c60827a10c0813945d03",
                "end_time": 1640120006.3039644,
                "parent_id": "cd5a9805b35afdfc",
                "http": {
                    "request": {
                        "url": "http://color.howto-ecs-basics.mesh.local:8080/",
                        "method": "GET",
                        "user_agent": "Go-http-client/1.1",
                        "client_ip": "10.0.88.84",
                        "x_forwarded_for": false
                    },
                    "response": {
                        "status": 200,
                        "content_length": 5
                    }
                },
                "aws": {
                    "app_mesh": {
                        "mesh_name": "howto-ecs-basics",
                        "virtual_node_name": "howto-ecs-basics-front-node"
                    }
                },
                "annotations": {
                    "response_flags": "-",
                    "component": "proxy",
                    "upstream_cluster": "cds_egress_howto-ecs-basics_howto-ecs-basics-color-node_http_8080",
                    "downstream_cluster": "-",
                    "request_size": "0",
                    "node_id": "mesh/howto-ecs-basics/virtualNode/howto-ecs-basics-front-node",
                    "direction": "egress"
                },
                "origin": "AWS::AppMesh::Proxy",
                "subsegments": [
                    {
                        "id": "0d09a9135dfb39a5",
                        "name": "howto-ecs-basics/howto-ecs-basics-front-node",
                        "start_time": 1640120006.3011773,
                        "end_time": 1640120006.303721,
                        "http": {
                            "request": {},
                            "response": {
                                "status": 200
                            }
                        },
                        "aws": {},
                        "annotations": {
                            "response_flags": "-",
                            "component": "proxy",
                            "upstream_cluster": "cds_egress_howto-ecs-basics_howto-ecs-basics-color-node_http_8080",
                            "upstream_address": "10.0.93.193:8080",
                            "direction": "egress"
                        }
                    }
                ]
            }
        }
```
